### PR TITLE
feat: Add right-associative binary operator support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -151,15 +151,24 @@ export default class ExpressionEval {
   static addBinaryOp(
     operator: string,
     precedence_or_fn: number | binaryCallback,
-    _function: binaryCallback)
+    _ra_or_callback?: boolean | binaryCallback,
+    _function?: binaryCallback)
     : void {
-    if (_function) {
-      jsep.addBinaryOp(operator, precedence_or_fn as number);
-      ExpressionEval.binops[operator] = _function;
+    let precedence, ra, cb;
+    if (typeof precedence_or_fn === 'function') {
+      cb = precedence_or_fn;
     } else {
-      jsep.addBinaryOp(operator, ExpressionEval.DEFAULT_PRECEDENCE[operator] || 1);
-      ExpressionEval.binops[operator] = precedence_or_fn as binaryCallback;
+      precedence = precedence_or_fn;
+      if (typeof _ra_or_callback === 'function') {
+        cb = _ra_or_callback;
+      } else {
+        ra = _ra_or_callback;
+        cb = _function;
+      }
     }
+
+    jsep.addBinaryOp(operator, precedence || 1, ra);
+    ExpressionEval.binops[operator] = cb;
   }
 
   // inject custom node evaluators (and override existing ones)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "jsep": "^1.1.0"
+        "jsep": "^1.2.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "jsep": "^1.1.0"
+    "jsep": "^1.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^14.1.0",

--- a/test.js
+++ b/test.js
@@ -108,6 +108,7 @@ const fixtures = [
   {expr: '3#4',         expected: 3.4   },
   {expr: '(1 # 2 # 3)', expected: 1.5   }, // Fails with undefined precedence, see issue #45
   {expr: '1 + 2 ~ 3',   expected: 9     }, // ~ is * but with low precedence
+  {expr: '2 ** 3 ** 4', expected: 2 ** 3 ** 4},
 
   // Arrow Functions
   {expr: '[1,2].find(v => v === 2)',                     expected: 2                                  },
@@ -201,6 +202,8 @@ expr.addUnaryOp('@', (a) => {
 expr.addBinaryOp('#', (a, b) => a + b / 10);
 
 expr.addBinaryOp('~', 1, (a, b) => a * b);
+
+expr.addBinaryOp('**', 11, true, (a, b) => a ** b);
 
 expr.addEvaluator('TestNodeType', function(node) { return node.test + this.context.string });
 


### PR DESCRIPTION
pass the boolean rightAssociative argument to addBinaryOp through to jsep