### PR TITLE
add jsep Compound expression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ _Forked from [expression-eval](https://github.com/donmccurdy/expression-eval]) v
 
 ## Usage
 Evaluates an [estree](https://github.com/estree/estree) expression from [jsep](https://github.com/EricSmekens/jsep)
-(as well as [@babel/parser][], [esprima][], [acorn][], or any other library that parses and returns a valid `estree` expression).
+(as well as [@babel/parser](https://babeljs.io/docs/en/babel-parser), [esprima](https://esprima.org/),
+[acorn](https://github.com/acornjs/acorn), or any other library that parses and returns a valid `estree` expression).
 
 
 ### Install
@@ -140,11 +141,14 @@ This project will try to stay current with all JSEP's node types::
 - `LogicalExpression`/`BinaryExpression`
 - `CallExpression`
 - `ConditionalExpression`
+- `Compound` *
 - `Identifier`
 - `Literal`
 - `MemberExpression`
 - `ThisExpression`
 - `UnaryExpression`
+
+**Compound support will evaluate each expression and return the result of the final one
 
 As well as the optional plugin node types:
 - `ArrowFunctionExpression`

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,7 @@ type AnyExpression = jsep.ArrayExpression
   | jsep.BinaryExpression
   | jsep.MemberExpression
   | jsep.CallExpression
+  | jsep.Compound
   | jsep.ConditionalExpression
   | jsep.Identifier
   | jsep.Literal
@@ -51,6 +52,7 @@ export default class ExpressionEval {
     'LogicalExpression': ExpressionEval.prototype.evalBinaryExpression,
     'BinaryExpression': ExpressionEval.prototype.evalBinaryExpression,
     'CallExpression': ExpressionEval.prototype.evalCallExpression,
+    'Compound': ExpressionEval.prototype.evalCompoundExpression,
     'ConditionalExpression': ExpressionEval.prototype.evalConditionalExpression,
     'Identifier': ExpressionEval.prototype.evalIdentifier,
     'Literal': ExpressionEval.evalLiteral,
@@ -268,6 +270,12 @@ export default class ExpressionEval {
     return this.isAsync
       ? Promise.all(leftRight).then(op)
       : op(leftRight as [operand, operand]);
+  }
+
+  private evalCompoundExpression(node: jsep.Compound) {
+    return this.isAsync
+      ? node.body.reduce((p: Promise<any>, node) => p.then(() => this.eval(node)), Promise.resolve())
+      : node.body.map(v => this.eval(v))[node.body.length - 1]
   }
 
   private evalCallExpression(node: jsep.CallExpression) {

--- a/test.js
+++ b/test.js
@@ -134,6 +134,9 @@ const fixtures = [
   {expr: '--a', expected: 0, context: {a: 1}, expObj: {a: 0}},
   {expr: 'a[0] = 3', expected: 3, context: {a: [0, 0]}, expObj: {a: [3, 0]}},
 
+  // compound
+  {expr: 'a=1; b=a; c=a+b;', expected: 2, context: {}, expObj: {a: 1, b: 1, c: 2}},
+
   // new
   {expr: '(new Date(2021, 8)).getFullYear()',             expected: 2021                          },
   {expr: '(new sub.sub2["Date"](2021, 8)).getFullYear()', expected: 2021                          },


### PR DESCRIPTION
adds `compound` expression support, which allows expressions like: `a = 1; b = a; c = a + b;`

Note, however, that JSEP does not support further expressions (i.e. `arr.map(v => { const x = 1; return x + 1; })`, where `const` and `return` are unknown syntax to JSEP).

Multiple non-assignment expressions would not make much sense: `a + 1; b + 2;`, which would simply return the final result. Therefore, I'm thinking it likely makes the most sense only with assignment operations.

Fixes #49