### PR TITLE
include "type" and "exports" key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "jse-eval",
-  "version": "0.0.1",
+  "version": "1.3.0",
   "description": "JavaScript expression parsing and evaluation.",
   "source": "index.ts",
+  "type": "module",
   "main": "dist/jse-eval.js",
   "module": "dist/jse-eval.module.js",
+  "exports": {
+    "import": "./dist/jse-eval.module.js",
+    "requires": "./dist/jse-eval.js"
+  },
   "unpkg": "dist/jse-eval.umd.js",
   "types": "dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
"type" and "exports" keys are missing from package.json in the npm package.