### PR TITLE
add `_value` to each node during evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jse-eval
 
 [![Latest NPM release](https://img.shields.io/npm/v/jse-eval.svg)](https://www.npmjs.com/package/jse-eval)
-[![License](https://img.shields.io/badge/license-MIT-007ec6.svg)](https://github.com/donmccurdy/jse-eval/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-007ec6.svg)](https://github.com/6utt3rfly/jse-eval/blob/master/LICENSE)
 [![CI](https://github.com/6utt3rfly/jse-eval/workflows/CI/badge.svg?branch=main&event=push)](https://github.com/6utt3rfly/jse-eval/actions?query=workflow%3ACI)
 <!-- [![Minzipped size](https://badgen.net/bundlephobia/minzip/jse-eval)](https://bundlephobia.com/result?p=jse-eval) -->
 

--- a/index.ts
+++ b/index.ts
@@ -211,7 +211,10 @@ export default class ExpressionEval {
     if (!evaluator) {
       throw new Error(`unknown node type: ${JSON.stringify(node, null, 2)}`);
     }
-    return this.evalSyncAsync(evaluator.bind(this)(node), cb);
+    return this.evalSyncAsync(evaluator.bind(this)(node), (v) => {
+      (node as any)._value = v;
+      return cb(v);
+    });
   }
 
   /*

--- a/test.js
+++ b/test.js
@@ -231,11 +231,14 @@ tape('sync', (t) => {
 
   [...fixtures, ...syncFixtures].forEach((o) => {
     const ctx = cloneDeep(o.context || context);
-    const val = JseEval.compile(o.expr)(ctx);
+    const ast = JseEval.jsep(o.expr);
+    const val = JseEval.evaluate(ast, ctx);
     const compare = t[typeof o.expected === 'object' ? 'deepEqual' : 'equal'];
     compare(val, o.expected, `${o.expr} (${val}) === ${o.expected}`);
     if (o.expObj) {
       t.deepEqual(ctx, o.expObj, `${o.expr} (${JSON.stringify(ctx)}) === ${JSON.stringify(o.expObj)}`);
+    } else {
+      compare(ast._value, o.expected, `${o.expr} (node._value ${val}) === ${o.expected}`);
     }
   });
 


### PR DESCRIPTION
Manipulates the ast and allows code regeneration tools to utilize the intermediate values of each node